### PR TITLE
Include gallery json in GH index commits

### DIFF
--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -41,7 +41,7 @@ jobs:
             $args = @{
               IndexPath = Resolve-Path ./index
               RegistryPath = Resolve-Path ./master/registry
-              GalleryJsonPath = $env:GALLERY_JSON
+              GalleryJsonPath = Resolve-Path "./index/$env:GALLERY_JSON"
               Token = $github.token
             }
             ./master/.github/scripts/Update-IndexCache.ps1 @args -Verbose


### PR DESCRIPTION
This PR moves the generated gallery .json file inside `index/`, which means it will be included in commits.

The benefit here is that the index can then be accessed via https://www.jsdelivr.com/documentation#id-github, a free CDN that allows any file in a github repo to be accessed without CORS headers. It does not support release artifacts, however, which is why I'd like the compiled json to committed to the `index` branch alongside all the existing yml files.